### PR TITLE
calculate mean EC50 values for replicates on a single day

### DIFF
--- a/test/__init__.py
+++ b/test/__init__.py
@@ -1,0 +1,1 @@
+import test.helpers.helpers

--- a/test/functional/test_example_data.py
+++ b/test/functional/test_example_data.py
@@ -4,25 +4,23 @@ from typing import Union
 import pytest
 import eccpy
 from tempfile import TemporaryDirectory
-from eccpy.tools import get_eccpy_module_path
-from openpyxl import load_workbook
 from pathlib import Path
-from shutil import copyfile
+
+from test.helpers.helpers import set_up_excel_settings_for_functional_test, get_replacement_dict_with_test_paths
 
 
 @pytest.mark.regression
 def test_processing_of_example_data():
-    eccpy_module_path: Union[Path, str] = get_eccpy_module_path()
-
     with TemporaryDirectory() as tmpdirname:
         # uncomment to view test output in repo dir during development
-        #tmpdirname: Union[Path, str] = eccpy_module_path / "test"
+        # tmpdirname: Union[Path, str] = eccpy_module_path / "test"
 
         tmpdir: Path = Path(tmpdirname)
         temp_path_for_testing: Union[Path, str] = tmpdir / "eccpy_temp_test_output"
         print(f" Test output will be saved to {temp_path_for_testing}, and deleted after tests are finished")
 
-        test_settings: Union[Path, str] = set_up_excel_settings_for_functional_test(temp_path_for_testing)
+        replacement_dict: dict = get_replacement_dict_with_test_paths(temp_path_for_testing)
+        test_settings: Union[Path, str] = set_up_excel_settings_for_functional_test(temp_path_for_testing, replacement_dict)
 
         eccpy.run_curvefit(test_settings)
         eccpy.run_gatherer(test_settings)
@@ -32,7 +30,7 @@ def test_processing_of_example_data():
         assert_gatherer_output_files_exist(temp_path_for_testing)
 
     # assert temporary output files are removed
-    assert not Path(tmpdirname).is_dir()
+    assert not Path(temp_path_for_testing).is_dir()
 
 
 def assert_gatherer_output_files_exist(temp_path_for_testing):
@@ -46,37 +44,3 @@ def assert_curvefit_output_files_exist(temp_path_for_testing):
     assert (temp_path_for_testing / "analysed").is_dir()
     assert (temp_path_for_testing / f"generated_data_0/curves/AA control.png").is_file()
     assert (temp_path_for_testing / f"generated_data_0/generated_data_0_summary.png").is_file()
-
-
-def set_up_excel_settings_for_functional_test(test_temp_output_path):
-    eccpy_module_path = get_eccpy_module_path()
-
-    orig_settings_xlsx: Union[Path, str] = eccpy_module_path / "eccpy/examples/example_settings/ECCpy_settings_template.xlsx"
-    temp_test_settings_xlsx: Union[Path, str] = test_temp_output_path / " settings_example_data.xlsx"
-
-    example_data_dir: Path = eccpy_module_path / "eccpy/examples/example_data"
-    #output_data_dir: str = str(eccpy_module_path / "test/temp_output")
-
-    if not temp_test_settings_xlsx.parent.is_dir():
-        temp_test_settings_xlsx.parent.mkdir(parents=True)
-
-    copyfile(orig_settings_xlsx, temp_test_settings_xlsx)
-    assert temp_test_settings_xlsx.is_file()
-
-    wb = load_workbook(temp_test_settings_xlsx)
-    sheet = "files"
-    input_data_cells = ["G2", "G3", "G4", "G5"]
-    output_data_cells = ["H2", "H3", "H4", "H5"]
-
-    ws = wb[sheet]
-
-    for cell in input_data_cells:
-        ws[cell] = str(example_data_dir)
-    for cell in output_data_cells:
-        ws[cell] = str(test_temp_output_path)
-
-    wb.save(temp_test_settings_xlsx)
-
-    return temp_test_settings_xlsx
-
-

--- a/test/functional/test_sample_replicates.py
+++ b/test/functional/test_sample_replicates.py
@@ -1,0 +1,62 @@
+import glob
+import pytest
+import eccpy
+import pandas as pd
+from eccpy.tools import get_eccpy_module_path
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from typing import Union
+from shutil import copyfile
+
+from test.helpers.helpers import get_replacement_dict_with_test_paths, set_up_excel_settings_for_functional_test, replace_xlsx_cells_by_replacement_dict
+
+
+@pytest.mark.regression
+def test_processing_of_example_data():
+    eccpy_module_path = get_eccpy_module_path()
+
+    with TemporaryDirectory() as tmpdirname:
+        # uncomment to view test output in repo dir during development
+        # tmpdirname: Union[Path, str] = eccpy_module_path / "test"
+
+        tmpdir: Path = Path(tmpdirname)
+        temp_path_for_testing: Union[Path, str] = tmpdir / "eccpy_temp_test_output"
+        print(f" Test output will be saved to {temp_path_for_testing}, and deleted after tests are finished")
+
+        example_data_dir: Path = eccpy_module_path / "eccpy/examples/example_data"
+        data_files_orig: list = glob.glob(str(example_data_dir / "*.xlsx"))
+        temp_example_data_dir: Path = temp_path_for_testing / "examples"
+        for data_file_path in data_files_orig:
+            assert Path(data_file_path).is_file()
+            destination = temp_example_data_dir / Path(data_file_path).name
+            if not destination.parent.is_dir():
+                destination.parent.mkdir(parents=True)
+            copyfile(data_file_path, destination)
+
+        data_file_0 = temp_example_data_dir / "generated_data_0.xlsx"
+        dose_replacements = {"B1": "sample1", "C1": "sample1", "D1": "sample1"}
+        response_replacements = {"B1": "sample1", "C1": "sample1", "D1": "sample1"}
+
+        replacement_dict = {}
+        replacement_dict["dose"] = dose_replacements
+        replacement_dict["response"] = response_replacements
+
+        replace_xlsx_cells_by_replacement_dict(replacement_dict, data_file_0)
+
+        replacement_dict: dict = get_replacement_dict_with_test_paths(temp_path_for_testing, temp_example_data_dir)
+        test_settings: Union[Path, str] = set_up_excel_settings_for_functional_test(temp_path_for_testing, replacement_dict)
+
+        eccpy.run_curvefit(test_settings)
+        eccpy.run_gatherer(test_settings)
+
+        output_data_0_xlsx: Path = temp_path_for_testing / f"generated_data_0/generated_data_0.xlsx"
+        assert output_data_0_xlsx.is_file()
+
+        df = pd.read_excel(output_data_0_xlsx, sheet_name="by_sample", index_col=0)
+        total_n_sample1_in_by_sample_tab = df.at["sample1", "n"] + df.at["sample1", "n_excluded"]
+        assert total_n_sample1_in_by_sample_tab == len(dose_replacements)
+        assert "mean" in df.columns
+        assert "std" in df.columns
+
+    # assert temporary output files are removed
+    assert not Path(temp_path_for_testing).is_dir()

--- a/test/helpers/helpers.py
+++ b/test/helpers/helpers.py
@@ -1,0 +1,50 @@
+from pathlib import Path
+from shutil import copyfile
+from typing import Union
+
+from openpyxl import load_workbook
+
+from eccpy.tools import get_eccpy_module_path
+
+
+def set_up_excel_settings_for_functional_test(temp_path_for_testing: Path, replacement_dict: dict) -> Path:
+    eccpy_module_path = get_eccpy_module_path()
+
+    orig_settings_xlsx: Union[Path, str] = eccpy_module_path / "eccpy/examples/example_settings/ECCpy_settings_template.xlsx"
+    temp_test_settings_xlsx: Union[Path, str] = temp_path_for_testing / " settings_example_data.xlsx"
+
+    if not temp_test_settings_xlsx.parent.is_dir():
+        temp_test_settings_xlsx.parent.mkdir(parents=True)
+
+    copyfile(orig_settings_xlsx, temp_test_settings_xlsx)
+    assert temp_test_settings_xlsx.is_file()
+
+    replace_xlsx_cells_by_replacement_dict(replacement_dict, temp_test_settings_xlsx)
+
+    return temp_test_settings_xlsx
+
+
+def replace_xlsx_cells_by_replacement_dict(replacement_dict: dict, xlsx_path: Union[Path, str]):
+    wb = load_workbook(xlsx_path)
+    for sheet, replacements in replacement_dict.items():
+        ws = wb[sheet]
+        for cell, value in replacements.items():
+            ws[cell] = value
+    wb.save(xlsx_path)
+
+
+def get_replacement_dict_with_test_paths(temp_path_for_testing, example_data_dir=None):
+    eccpy_module_path = get_eccpy_module_path()
+    if not example_data_dir:
+        example_data_dir: Path = eccpy_module_path / "eccpy/examples/example_data"
+    replacement_dict = {}
+    files_replacements: dict = {}
+    input_data_cells = ["G2", "G3", "G4", "G5"]
+    output_data_cells = ["H2", "H3", "H4", "H5"]
+    for cell in input_data_cells:
+        files_replacements[cell] = str(example_data_dir)
+    for cell in output_data_cells:
+        files_replacements[cell] = str(temp_path_for_testing)
+    replacement_dict["files"] = files_replacements
+
+    return replacement_dict


### PR DESCRIPTION
#8 
saved in a new tab "by_sample" in the output for a single run/experiment
the mean data for replicates in a single run/experiment is currently
 NOT used in the gather scripts for combining multiple runs